### PR TITLE
Added git version note for AWS SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .jekyll-metadata
+.jekyll-cache
 
 _site/
 .bundle/

--- a/docs/_posts/2020-04-13-stream-from-raspberry-pi-to-amazon-kinesis.md
+++ b/docs/_posts/2020-04-13-stream-from-raspberry-pi-to-amazon-kinesis.md
@@ -104,8 +104,9 @@ $ sudo apt-get install gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad g
 
 ```
 $ cd /home/pi/Downloads
-$ git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp
+$ git clone --branch '2.1.0' https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp
 ```
+(you should take version 2.1.0 to make it work since there is a new folders' structure and build tactics since version 3.0)
 
 - Change your current working directory to the install directory and run the `min-install-script` script to build the Producer SDK:
 


### PR DESCRIPTION
Hi Martin, we had a quick discussion in LinkedIn, since AWS changed folders structure in their SDK starting from version 3.0, therefore, I have added a note to fetch version 2.1.0 for other readers to make it work.

Best,
Maryan